### PR TITLE
add defaul css rules in dedicated stylesheet file

### DIFF
--- a/Control.FullScreen.css
+++ b/Control.FullScreen.css
@@ -1,0 +1,2 @@
+.leaflet-control-zoom-fullscreen { background-image: url(icon-fullscreen.png); }
+.leaflet-container:-webkit-full-screen { width: 100% !important; height: 100% !important; }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Released under the MIT License http://opensource.org/licenses/mit-license.php
 How ?
 ------
 
+Include Control.FullScreen.js and Control.FullScreen.css in your page:
+
+```
+ <link rel="stylesheet" href="Control.FullScreen.css" />
+ <script src="Control.FullScreen.js"></script>
+```
+
 Add the fullscreen control to the map:
 
 ```
@@ -56,7 +63,8 @@ map.on('exitFullscreen', function(){
 });
 ```
 
-Add this style to your css:
+If you don't want to add the Control.FullScreen.css stylesheet to your
+HTML-head, Add this style to your css:
 
 ```
 .leaflet-control-zoom-fullscreen { background-image: url(icon-fullscreen.png); }


### PR DESCRIPTION
I'm a person who looks more intense to the code instead of a README.md file. So I overlooked the section, where it is explained which styles should be copied to your custom stylesheet file. I didn't get the button's icon displayed and thought, that this might be a bug.

I added a Control.FullScreen.css file, because I think it belongs to this package. I like it to have least possible integration work, and with this change, I just have to include another css file. The extra http request can be easily avoided by: 1) Integrating the css like before, 2) using an css compiler which merges all css files into one.
