### PR TITLE
Fixed bug where full screen is not supported and there is no zoom control.

### DIFF
--- a/Control.FullScreen.js
+++ b/Control.FullScreen.js
@@ -8,7 +8,7 @@ L.Control.FullScreen = L.Control.extend({
 	onAdd: function (map) {
 		// Do nothing if we can't
 		if (!fullScreenApi.supportsFullScreen)
-			return map.zoomControl._container;
+			return map.zoomControl ? map.zoomControl._container : L.DomUtil.create('div', '');
 		
 		var containerClass = 'leaflet-control-zoom', className, container;
 		


### PR DESCRIPTION
If this control is added before adding the zoom control, it causes a javascript error when run on iOS device.
