### PR TITLE
Can't type any letters or numbers in text inputs in fullscreen mode on webkit browsers

### DIFF
--- a/Control.FullScreen.js
+++ b/Control.FullScreen.js
@@ -135,7 +135,7 @@ source : http://johndyer.name/native-fullscreen-javascript-api-plus-jquery-plugi
 			}
 		}
 		fullScreenApi.requestFullScreen = function(el) {
-			return (this.prefix === '') ? el.requestFullscreen() : el[this.prefix + 'RequestFullScreen']();
+			return (this.prefix === '') ? el.requestFullscreen() : el[this.prefix + 'RequestFullScreen'](Element.ALLOW_KEYBOARD_INPUT);
 		}
 		fullScreenApi.cancelFullScreen = function(el) {
 			return (this.prefix === '') ? document.exitFullscreen() : document[this.prefix + 'CancelFullScreen']();


### PR DESCRIPTION
Can't type any letters or numbers in text inputs in fullscreen mode on webkit browsers.

@see http://stackoverflow.com/questions/16266897/cant-type-any-letters-or-numbers-in-text-inputs-in-fullscreen-mode-on-webkit-br
