### PR TITLE
Add bower.json, closes #32

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,30 @@
+{
+  "name": "leaflet.fullscreen",
+  "version": "1.1.3",
+  "homepage": "https://github.com/brunob/leaflet.fullscreen",
+  "authors": [
+    "brunob <brunobergot@gmail.com>"
+  ],
+  "description": "Leaflet.Control.FullScreen for Leaflet",
+  "main": [
+    "Control.FullScreen.js",
+    "Control.FullScreen.css",
+    "icon-fullscreen.png",
+    "icon-fullscreen-2x.png"
+  ],
+  "keywords": [
+    "leaflet",
+    "plugins",
+    "maps",
+    "fullscreen"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "index.html"
+  ]
+}


### PR DESCRIPTION
By defining the [main](https://github.com/bower/bower.json-spec#main) property, tools like [wiredep](https://github.com/taptapship/wiredep) are able to inject
source files into `index.html` automatically (for example).

Note, Bower doesn't read `package.json`. Since this is a frontend package, you
might consider removing it.

Also, there are currently two packages of this repo in the Bower registry:

``` shell
❯ bower search leaflet.fullscreen
Search results:

    leaflet-fullscreen git://github.com/brunob/leaflet.fullscreen.git
    leaflet.fullscreen git://github.com/brunob/leaflet.fullscreen.git
```

Since you're the repo owner, you might consider [unregistering](http://bower.io/docs/creating-packages/#unregister) one (or both
if you merge this pull request; re-registering afterwards) to prevent confusion.
