### PR TITLE
Fix jQuery condition

### DIFF
--- a/Control.FullScreen.js
+++ b/Control.FullScreen.js
@@ -148,7 +148,7 @@ source : http://johndyer.name/native-fullscreen-javascript-api-plus-jquery-plugi
 	}
 
 	// jQuery plugin
-	if (typeof jQuery !== 'undefined') {
+	if (window.jQuery) {
 		jQuery.fn.requestFullScreen = function() {
 			return this.each(function() {
 				var el = jQuery(this);


### PR DESCRIPTION
Throws `ReferenceError: Can't find variable: jQuery` otherwise