### PR TITLE
add delay for map.invalidateSize() call to avoid some lags detected

### DIFF
--- a/Control.FullScreen.js
+++ b/Control.FullScreen.js
@@ -65,7 +65,7 @@ L.Control.FullScreen = L.Control.extend({
 			} else {
 				L.DomUtil.removeClass(map._container, 'leaflet-pseudo-fullscreen');
 			}
-			map.invalidateSize();
+			setTimeout(L.bind(map.invalidateSize, map), 200);
 			map.fire('exitFullscreen');
 			map._exitFired = true;
 			map._isFullscreen = false;
@@ -76,7 +76,7 @@ L.Control.FullScreen = L.Control.extend({
 			} else {
 				L.DomUtil.addClass(map._container, 'leaflet-pseudo-fullscreen');
 			}
-			map.invalidateSize();
+			setTimeout(L.bind(map.invalidateSize, map), 200);
 			map.fire('enterFullscreen');
 			map._isFullscreen = true;
 		}


### PR DESCRIPTION
I've discovered problems for Chrome in mobile device emulation mode:
map.getSize() get wrong value after switching to fullscreen mode.
Adding delay like this **_setTimeout(L.bind(map.invalidateSize, map), 200);_** solve my problem. So I wish it
helps another ones.
