### PR TITLE
Updates to mouseclick handlers

### DIFF
--- a/Control.FullScreen.js
+++ b/Control.FullScreen.js
@@ -72,8 +72,9 @@
 			this.link.setAttribute('aria-label', title);
 
 			L.DomEvent
-				.on(this.link, 'click', L.DomEvent.stopPropagation)
+                .on(this.link, 'mousedown dblclick click', L.DomEvent.stopPropagation)
 				.on(this.link, 'click', L.DomEvent.preventDefault)
+                .on(this.link, 'click', this._refocusOnMap, this)
 				.on(this.link, 'click', fn, context);
 			
 			L.DomEvent

--- a/Control.FullScreen.js
+++ b/Control.FullScreen.js
@@ -72,9 +72,9 @@
 			this.link.setAttribute('aria-label', title);
 
 			L.DomEvent
-                .on(this.link, 'mousedown dblclick click', L.DomEvent.stopPropagation)
+				.on(this.link, 'mousedown dblclick click', L.DomEvent.stopPropagation)
 				.on(this.link, 'click', L.DomEvent.preventDefault)
-                .on(this.link, 'click', this._refocusOnMap, this)
+				.on(this.link, 'click', this._refocusOnMap, this)
 				.on(this.link, 'click', fn, context);
 			
 			L.DomEvent


### PR DESCRIPTION
Prevent click and drag on the button from dragging the map.
Return focus to the map after the click is handled.