### PR TITLE
Update UMD definition

### DIFF
--- a/Control.FullScreen.js
+++ b/Control.FullScreen.js
@@ -15,7 +15,7 @@
 		// Save 'screenfull' into global window variable
 		root.screenfull = factory();
 	}
-}(this, function () {
+}(typeof self !== 'undefined' ? self : this, function () {
 	'use strict';
 
 	var document = typeof window !== 'undefined' && typeof window.document !== 'undefined' ? window.document : {};
@@ -198,7 +198,7 @@
 		// Assume 'leaflet' and 'screenfull' are loaded into global variable already
 		factory(root.L, root.screenfull);
 	}
-}(this, function (leaflet, screenfull) {
+}(typeof self !== 'undefined' ? self : this, function (leaflet, screenfull) {
 	'use strict';
 
 	leaflet.Control.FullScreen = leaflet.Control.extend({


### PR DESCRIPTION
The current definition does not allow an easy usage in module contexts, for example the following throws "[root](https://github.com/brunob/leaflet.fullscreen/blob/d1f12fa4432bb2225979ff4051e65e647056b7d1/Control.FullScreen.js#L16)" is undefined error:

```html
<script type="text/javascript">

  import('https://unpkg.com/leaflet.fullscreen').then(()=>{ /* do stuff */ });

</script>
```

also when using bundlers (eg. [rollup](https://github.com/Raruto/leaflet-ui/blob/427fbdbcab9f368d4b64c5700c28143381d9e07d/build/rollup.config.js#L36)) you requires some special caveats, eg:

```js
  moduleContext: { "node_modules/leaflet.fullscreen/Control.FullScreen.js": "window" },
```

**Reference:**

- [https://github.com/umdjs/umd/templates/amdWeb.js](https://github.com/umdjs/umd/blob/36fd1135ba44e758c7371e7af72295acdebce010/templates/amdWeb.js)
- https://caniuse.com/?search=self

Alternatively you could use the `globalThis` variable as well:

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
- https://caniuse.com/?search=globalThis

_Have a nice day,
Raruto_