### PR TITLE
fix: prevent error on ios

### DIFF
--- a/Control.FullScreen.js
+++ b/Control.FullScreen.js
@@ -241,13 +241,15 @@
 				.off(this.link, 'click', leaflet.DomEvent.stop)
 				.off(this.link, 'click', this.toggleFullScreen, this);
 
-			leaflet.DomEvent
-				.off(this._container, this._screenfull.raw.fullscreenchange, leaflet.DomEvent.stop)
-				.off(this._container, this._screenfull.raw.fullscreenchange, this._handleFullscreenChange, this);
+			if (this._screenfull.isEnabled) {
+				leaflet.DomEvent
+					.off(this._container, this._screenfull.raw.fullscreenchange, leaflet.DomEvent.stop)
+					.off(this._container, this._screenfull.raw.fullscreenchange, this._handleFullscreenChange, this);
 
-			leaflet.DomEvent
-				.off(document, this._screenfull.raw.fullscreenchange, leaflet.DomEvent.stop)
-				.off(document, this._screenfull.raw.fullscreenchange, this._handleFullscreenChange, this);
+				leaflet.DomEvent
+					.off(document, this._screenfull.raw.fullscreenchange, leaflet.DomEvent.stop)
+					.off(document, this._screenfull.raw.fullscreenchange, this._handleFullscreenChange, this);
+			}
 		},
 
 		_createButton: function (title, className, content, container, fn, context) {
@@ -265,13 +267,15 @@
 				.on(this.link, 'click', leaflet.DomEvent.stop)
 				.on(this.link, 'click', fn, context);
 
-			leaflet.DomEvent
-				.on(container, this._screenfull.raw.fullscreenchange, leaflet.DomEvent.stop)
-				.on(container, this._screenfull.raw.fullscreenchange, this._handleFullscreenChange, context);
+			if (this._screenfull.isEnabled) {
+				leaflet.DomEvent
+					.on(container, this._screenfull.raw.fullscreenchange, leaflet.DomEvent.stop)
+					.on(container, this._screenfull.raw.fullscreenchange, this._handleFullscreenChange, context);
 
-			leaflet.DomEvent
-				.on(document, this._screenfull.raw.fullscreenchange, leaflet.DomEvent.stop)
-				.on(document, this._screenfull.raw.fullscreenchange, this._handleFullscreenChange, context);
+				leaflet.DomEvent
+					.on(document, this._screenfull.raw.fullscreenchange, leaflet.DomEvent.stop)
+					.on(document, this._screenfull.raw.fullscreenchange, this._handleFullscreenChange, context);
+			}
 
 			return this.link;
 		},


### PR DESCRIPTION
by checking screenfull is enabled in onRemove and _createButton

Fix: #99 & #101