### PR TITLE
Remove dependency on screenfull - fix issue#107

### DIFF
--- a/Control.FullScreen.js
+++ b/Control.FullScreen.js
@@ -65,7 +65,7 @@
 		error: nativeAPI.fullscreenerror,
 	};
 
-	const screenfull = {
+	const fullscreenAPI = {
 		request: function (element, options) {
 			return new Promise(function (resolve, reject) {
 				const onFullScreenEntered = function () {
@@ -115,7 +115,7 @@
 		nativeAPI: nativeAPI
 };
 
-	Object.defineProperties(screenfull, {
+	Object.defineProperties(fullscreenAPI, {
 		isFullscreen: {
 			get: function () {
 				return Boolean(document[nativeAPI.fullscreenElement]);
@@ -140,7 +140,7 @@
 			fullscreenElement: false
 		},
 
-		_screenfull: screenfull,
+		_screenfull: fullscreenAPI,
 
 		onAdd: function (map) {
 			var className = 'leaflet-control-zoom-fullscreen', container, content = '';

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 Leaflet.Control.FullScreen
 ============
 
+What's new ?
+------
+
+**Version 3**
+
+Integrates usage of the Full Screen API without using the screenfull package.
+
+This plugin requires browsers supporting the Full Screen API (i.e. all quite current browsers) or Safari from version 6 on.  
+For details about what browsers do support this api see the [CanIuse](https://caniuse.com/fullscreen) web site.
+
+This version does no longer support the MS Internet Explorer.
+
 What ?
 ------
 
@@ -41,7 +53,7 @@ If your map doesn't have a zoomControl the fullscreen button will be added to to
 
 If you want to use the plugin on a map embedded in an iframe, don't forget to set `allowfullscreen` attribute on your iframe.
 
-__Events and options__:
+__Option, events and methods__:
 
 ``` js
 // create a fullscreen button and add it to the map

--- a/index.html
+++ b/index.html
@@ -13,9 +13,11 @@
 	<script src="Control.FullScreen.js"></script>
 </head>
 <body>
-
 	<div id="map"></div>
-
+	<div style="margin:1em 0 0;">
+		<span style="padding:0 0.25em 0 0;">Demonstration of 'toggleFullscreen' method</span>
+		<button type="button" onclick="toggleFullscreen();">Show map in fullscreen mode</button>
+	</div>
 	<script>
 		var base = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
 			maxZoom: 19,
@@ -42,6 +44,11 @@
 		map.on('exitFullscreen', function(){
 			if(window.console) window.console.log('exitFullscreen');
 		});
-	</script>
+
+		// toggler into fullscreen mode
+		const toggleFullscreen = function(){
+			map.toggleFullscreen();
+		}
+</script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet.fullscreen",
-  "version": "2.4.0",
+  "version": "3.0.0-rc.0",
   "description": "Simple plugin for Leaflet that adds fullscreen button to your maps.",
   "main": "Control.FullScreen.js",
   "scripts": {


### PR DESCRIPTION
In some scenarios (e.g. commonjs environments) there exist problems with the dependency on the screenfull package. This package is a second export of the leaflet.fullscreen package, but this seems not to work in some configurations.

As screenfull is only a thin wrapper around the fullscreen api available in all modern browsers, this pr integrates the required calls to the fullscreen api into the leaflet.fullscreen package as internal methods.

As all major browsers support the fullscreen api since more than 4 years and since IE is no longer supported by microsoft, I dropped the support of older browsers / IE (but this could be changed easily).  
The only exception is the safari browser on apple devices that only support the complete api since march 2023. Here older versions are supported too.

I tested this pr in the demo page included in the package and in the commonjs demo (using hugo) from @taviowong.
To enable more tests, I set the version in the package.json file to v 3.0.0-rc.0, so that this pr could be published as a prerelease (using `npm publish --tag next`).

Perhaps some of the other users (@barbalex or @ricfio) could test this release candidate too (with `npm i leaflet.fullscreen@next`) and give some feedback. I would appreciate this very much.