### PR TITLE
ci: add simple github action to run lint on PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,10 @@
+name: Lint
+on: [push, pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - run: npm ci
+      - run: npm run lint


### PR DESCRIPTION
largely inspired by https://github.com/leaflet-extras/leaflet-providers/blob/master/.github/workflows/ci.yml