### PR TITLE
chore: switch from @stylistic/eslint-plugin to @stylistic/eslint-plugin-js

### DIFF
--- a/Control.FullScreen.js
+++ b/Control.FullScreen.js
@@ -3,7 +3,7 @@
  * (c) Bruno B.; MIT License
  * Uses fragments from the package 'screenfull'
  */
-(function (root, factory) {
+(function(root, factory) {
 	if (typeof define === 'function' && define.amd) {
 		// define an AMD module that requires 'leaflet'
 		// and resolve to an object containing leaflet
@@ -70,7 +70,7 @@
 	const fullscreenAPI = {
 		request(element, options) {
 			return new Promise((resolve, reject) => {
-				const onFullScreenEntered = function () {
+				const onFullScreenEntered = function() {
 					this.off('change', onFullScreenEntered);
 					resolve();
 				}.bind(this);
@@ -90,7 +90,7 @@
 					return;
 				}
 
-				const onFullScreenExit = function () {
+				const onFullScreenExit = function() {
 					this.off('change', onFullScreenExit);
 					resolve();
 				}.bind(this);
@@ -270,13 +270,13 @@
 		}
 	});
 
-	leaflet.Map.addInitHook(function () {
+	leaflet.Map.addInitHook(function() {
 		if (this.options.fullscreenControl) {
 			this.addControl(leaflet.control.fullscreen(this.options.fullscreenControlOptions));
 		}
 	});
 
-	leaflet.control.fullscreen = function (options) {
+	leaflet.control.fullscreen = function(options) {
 		return new leaflet.Control.FullScreen(options);
 	};
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,6 @@
 import globals from 'globals';
 import eslintPluginEslint from '@eslint/js';
-import eslintPluginStylistic from '@stylistic/eslint-plugin';
+import eslintPluginStylistic from '@stylistic/eslint-plugin-js';
 
 const config = [
 	{
@@ -14,16 +14,24 @@ const config = [
 			}
 		},
 		plugins: {
-			...eslintPluginStylistic.configs['recommended-flat'].plugins
+			...eslintPluginStylistic.configs['all-flat'].plugins
 		},
 		rules: {
 			...eslintPluginEslint.configs['recommended'].rules,
-			...eslintPluginStylistic.configs['recommended-flat'].rules,
-			'@stylistic/brace-style': ['error', '1tbs'],
-			'@stylistic/comma-dangle': ['error', 'only-multiline'],
-			'@stylistic/indent': ['error', 'tab'],
-			'@stylistic/no-tabs': 'off',
-			'@stylistic/semi': ['error', 'always'],
+			...eslintPluginStylistic.configs['all-flat'].rules,
+			'@stylistic/js/brace-style': ['error', '1tbs'],
+			'@stylistic/js/comma-dangle': ['error', 'only-multiline'],
+			'@stylistic/js/dot-location': ['error', 'property'],
+			'@stylistic/js/function-call-argument-newline': ['error', 'consistent'],
+			'@stylistic/js/indent': ['error', 'tab'],
+			'@stylistic/js/multiline-comment-style': 'off',
+			'@stylistic/js/no-tabs': 'off',
+			'@stylistic/js/object-curly-spacing': ['error', 'always'],
+			'@stylistic/js/padded-blocks': 'off',
+			'@stylistic/js/quotes': ['error', 'single'],
+			'@stylistic/js/quote-props': ['error', 'consistent-as-needed'],
+			'@stylistic/js/semi': ['error', 'always'],
+			'@stylistic/js/space-before-function-paren': ['error', 'never'],
 			'no-lonely-if': 'error',
 			'no-unused-expressions': ['error', { allowTernary: true }]
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.6.0",
-        "@stylistic/eslint-plugin": "^2.3.0",
+        "@stylistic/eslint-plugin-js": "^2.3.0",
         "eslint": "^9.6.0",
         "prettier": "^3.3.2",
         "stylelint": "^16.6.1",
@@ -458,26 +458,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@stylistic/eslint-plugin": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.3.0.tgz",
-      "integrity": "sha512-rtiz6u5gRyyEZp36FcF1/gHJbsbT3qAgXZ1qkad6Nr/xJ9wrSJkiSFFQhpYVTIZ7FJNRJurEcumZDCwN9dEI4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@stylistic/eslint-plugin-js": "2.3.0",
-        "@stylistic/eslint-plugin-jsx": "2.3.0",
-        "@stylistic/eslint-plugin-plus": "2.3.0",
-        "@stylistic/eslint-plugin-ts": "2.3.0",
-        "@types/eslint": "^8.56.10"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=8.40.0"
-      }
-    },
     "node_modules/@stylistic/eslint-plugin-js": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.3.0.tgz",
@@ -495,116 +475,6 @@
       },
       "peerDependencies": {
         "eslint": ">=8.40.0"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-jsx": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-2.3.0.tgz",
-      "integrity": "sha512-tsQ0IEKB195H6X9A4iUSgLLLKBc8gUBWkBIU8tp1/3g2l8stu+PtMQVV/VmK1+3bem5FJCyvfcZIQ/WF1fsizA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@stylistic/eslint-plugin-js": "^2.3.0",
-        "@types/eslint": "^8.56.10",
-        "estraverse": "^5.3.0",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=8.40.0"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-jsx/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-plus": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-2.3.0.tgz",
-      "integrity": "sha512-xboPWGUU5yaPlR+WR57GwXEuY4PSlPqA0C3IdNA/+1o2MuBi95XgDJcZiJ9N+aXsqBXAPIpFFb+WQ7QEHo4f7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "^8.56.10",
-        "@typescript-eslint/utils": "^7.12.0"
-      },
-      "peerDependencies": {
-        "eslint": "*"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-plus/node_modules/@typescript-eslint/utils": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.15.0.tgz",
-      "integrity": "sha512-hfDMDqaqOqsUVGiEPSMLR/AjTSCsmJwjpKkYQRo1FNbmW4tBwBspYDwO9eh7sKSTwMQgBw9/T4DHudPaqshRWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.15.0",
-        "@typescript-eslint/types": "7.15.0",
-        "@typescript-eslint/typescript-estree": "7.15.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-ts": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-2.3.0.tgz",
-      "integrity": "sha512-wqOR38/uz/0XPnHX68ftp8sNMSAqnYGjovOTN7w00xnjS6Lxr3Sk7q6AaxWWqbMvOj7V2fQiMC5HWAbTruJsCg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@stylistic/eslint-plugin-js": "2.3.0",
-        "@types/eslint": "^8.56.10",
-        "@typescript-eslint/utils": "^7.12.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=8.40.0"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin-ts/node_modules/@typescript-eslint/utils": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.15.0.tgz",
-      "integrity": "sha512-hfDMDqaqOqsUVGiEPSMLR/AjTSCsmJwjpKkYQRo1FNbmW4tBwBspYDwO9eh7sKSTwMQgBw9/T4DHudPaqshRWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.15.0",
-        "@typescript-eslint/types": "7.15.0",
-        "@typescript-eslint/typescript-estree": "7.15.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
       }
     },
     "node_modules/@types/eslint": {
@@ -631,124 +501,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.15.0.tgz",
-      "integrity": "sha512-Q/1yrF/XbxOTvttNVPihxh1b9fxamjEoz2Os/Pe38OHwxC24CyCqXxGTOdpb4lt6HYtqw9HetA/Rf6gDGaMPlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "7.15.0",
-        "@typescript-eslint/visitor-keys": "7.15.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-aV1+B1+ySXbQH0pLK0rx66I3IkiZNidYobyfn0WFsdGhSXw+P3YOqeTq5GED458SfB24tg+ux3S+9g118hjlTw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.15.0.tgz",
-      "integrity": "sha512-gjyB/rHAopL/XxfmYThQbXbzRMGhZzGw6KpcMbfe8Q3nNQKStpxnUKeXb0KiN/fFDR42Z43szs6rY7eHk0zdGQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/types": "7.15.0",
-        "@typescript-eslint/visitor-keys": "7.15.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.15.0.tgz",
-      "integrity": "sha512-Hqgy/ETgpt2L5xueA/zHHIl4fJI2O4XUE9l4+OIfbJIRSnTJb/QscncdqqZzofQegIJugRIF57OJea1khw2SDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "7.15.0",
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
     },
     "node_modules/acorn": {
       "version": "8.12.0",
@@ -2137,19 +1889,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2549,19 +2288,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/ts-api-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
-      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.2.0"
-      }
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2580,6 +2306,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "devDependencies": {
     "@eslint/js": "^9.6.0",
-    "@stylistic/eslint-plugin": "^2.3.0",
+    "@stylistic/eslint-plugin-js": "^2.3.0",
     "eslint": "^9.6.0",
     "prettier": "^3.3.2",
     "stylelint": "^16.6.1",


### PR DESCRIPTION
With this PR there will be no more warnings during `npm install`.

Since `@stylistic/eslint-plugin-js` has no recommended config, I choose the all-flat config and adapted some of the rules to the current code style.