### PR TITLE
fix: use leaflet specific classname for fullscreen icon to not affect…

### DIFF
--- a/Control.FullScreen.css
+++ b/Control.FullScreen.css
@@ -1,17 +1,17 @@
-.fullscreen-icon {
+.leaflet-fullscreen-icon {
 	background-image: url('icon-fullscreen.svg');
 	background-size: 26px 52px;
 }
 
-.fullscreen-icon.leaflet-fullscreen-on {
+.leaflet-fullscreen-icon.leaflet-fullscreen-on {
 	background-position: 0 -26px;
 }
 
-.leaflet-touch .fullscreen-icon {
+.leaflet-touch .leaflet-fullscreen-icon {
 	background-position: 2px 2px;
 }
 
-.leaflet-touch .fullscreen-icon.leaflet-fullscreen-on {
+.leaflet-touch .leaflet-fullscreen-icon.leaflet-fullscreen-on {
 	background-position: 2px -24px;
 }
 

--- a/Control.FullScreen.js
+++ b/Control.FullScreen.js
@@ -158,7 +158,7 @@
 			if (this.options.content) {
 				content = this.options.content;
 			} else {
-				className += ' fullscreen-icon';
+				className += ' leaflet-fullscreen-icon';
 			}
 
 			this._createButton(this.options.title, className, content, container, this.toggleFullScreen, this);


### PR DESCRIPTION
… other places that use the classname 'fullscreen-icon'

This is a breaking change in case users of the library overwrite fullscreen-icon styles locally. But a simple string replacement (".fullscreen-icon" -> ".leaflet-fullscreen-icon") in their repo will fix it.