### PR TITLE
fix: add aria-label to fullscreen toggle state

### DIFF
--- a/Control.FullScreen.js
+++ b/Control.FullScreen.js
@@ -248,6 +248,9 @@
 			this.link.title = this._map._isFullscreen
 				? this.options.title
 				: this.options.titleCancel;
+			this.link.setAttribute('aria-label', this._map._isFullscreen
+				? this.options.title
+				: this.options.titleCancel);
 			this._map._isFullscreen
 				? L.DomUtil.removeClass(this.link, 'leaflet-fullscreen-on')
 				: L.DomUtil.addClass(this.link, 'leaflet-fullscreen-on');


### PR DESCRIPTION
The aria-label is excluded from the toggle update, so the value remains the same in fullscreen mode.