### PR TITLE
ci: add github pages workflow for demos

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -3,6 +3,11 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: ['master']
+    paths:
+      - 'index.html'
+      - 'icon-fullscreen.svg'
+      - 'demo/**'
+      - 'dist/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automatically deploy the demos to GitHub Pages using the official `actions/deploy-pages`. This ensures the live demo is always in sync with `master`.

@brunob: You have to setup this to work: Go to **Settings > Pages > Build and deployment** and change the **Source** to **GitHub Actions**. I recommend doing this before merging.