### PR TITLE
fix(build): simplify UMD global to L.Control.FullScreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,14 @@ If you want to host the files yourself, you can download them from [npm](https:/
 Add the fullscreen control to the map:
 
 ```js
-let map = new L.Map('map', {
-	fullscreenControl: true,
-	fullscreenControlOptions: {
-		position: 'topleft'
-	}
-});
+const map = L.map('map');
+
+map.addControl(new L.Control.FullScreen());
 ```
 
-If your map has a zoomControl the fullscreen button will be added at the bottom of this one.
+If your map has a zoomControl, the fullscreen button will be added at the bottom of it.
 
-If your map doesn't have a zoomControl the fullscreen button will be added to topleft corner of the map (same as the zoomControl).
+If your map doesn't have a zoomControl, the fullscreen button will be added to the topleft corner of the map (default position).
 
 If you want to use the plugin on a map embedded in an iframe, don't forget to set `allowfullscreen` attribute on your iframe.
 
@@ -38,17 +35,15 @@ If you want to use the plugin on a map embedded in an iframe, don't forget to se
 
 ```js
 // create a fullscreen button and add it to the map
-L.control
-	.fullscreen({
-		position: 'topleft', // change the position of the button can be topleft, topright, bottomright or bottomleft, default topleft
-		title: 'Show me the fullscreen !', // change the title of the button, default Full Screen
-		titleCancel: 'Exit fullscreen mode', // change the title of the button when fullscreen is on, default Exit Full Screen
-		content: null, // change the content of the button, can be HTML, default null
-		forceSeparateButton: true, // force separate button to detach from zoom buttons, default false
-		forcePseudoFullscreen: true, // force use of pseudo full screen even if full screen API is available, default false
-		fullscreenElement: false // Dom element to render in full screen, false by default, fallback to map._container
-	})
-	.addTo(map);
+new L.Control.FullScreen({
+	position: 'topleft', // change the position of the button can be topleft, topright, bottomright or bottomleft, default topleft
+	title: 'Show me the fullscreen !', // change the title of the button, default Full Screen
+	titleCancel: 'Exit fullscreen mode', // change the title of the button when fullscreen is on, default Exit Full Screen
+	content: null, // change the content of the button, can be HTML, default null
+	forceSeparateButton: true, // force separate button to detach from zoom buttons, default false
+	forcePseudoFullscreen: true, // force use of pseudo full screen even if full screen API is available, default false
+	fullscreenElement: false // Dom element to render in full screen, false by default, fallback to map._container
+}).addTo(map);
 
 // events are fired when entering or exiting fullscreen.
 map.on('enterFullscreen', function () {
@@ -115,19 +110,14 @@ To use this plugin with a bundler (Webpack, Vite, etc.):
    <link rel="stylesheet" href="node_modules/leaflet.fullscreen/dist/Control.FullScreen.css" />
    ```
 
-Alternatively, you can use the classic approach with side effects:
+Alternatively, you can use the default export:
 
 ```js
-import L from 'leaflet';
-import 'leaflet.fullscreen';
+import FullScreen from 'leaflet.fullscreen';
 import 'leaflet.fullscreen/dist/Control.FullScreen.css';
 
-const map = new L.Map('map', {
-	fullscreenControl: true,
-	fullscreenControlOptions: {
-		position: 'topleft'
-	}
-});
+const map = L.map('map');
+map.addControl(new FullScreen());
 ```
 
 ## Contributing

--- a/demo/demo.umd.html
+++ b/demo/demo.umd.html
@@ -60,7 +60,7 @@
 
 			// Add fullscreen control
 			map.addControl(
-				new L.Control.FullScreen.FullScreen({
+				new L.Control.FullScreen({
 					position: 'topleft',
 					title: 'Show me the fullscreen!',
 					titleCancel: 'Exit fullscreen mode'

--- a/dist/Control.FullScreen.js
+++ b/dist/Control.FullScreen.js
@@ -274,4 +274,4 @@ Map.include({
 	}
 });
 
-export { FullScreen };
+export { FullScreen, FullScreen as default };

--- a/dist/Control.FullScreen.umd.js
+++ b/dist/Control.FullScreen.umd.js
@@ -5,10 +5,10 @@
  */
 /*! GENERATED FILE - DO NOT EDIT DIRECTLY. Edit files in src/ and run 'npm run build' */
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('leaflet')) :
-	typeof define === 'function' && define.amd ? define(['exports', 'leaflet'], factory) :
-	(global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory((global.L = global.L || {}, global.L.Control = global.L.Control || {}, global.L.Control.FullScreen = {}), global.L));
-})(this, (function (exports, leaflet) { 'use strict';
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('leaflet')) :
+	typeof define === 'function' && define.amd ? define(['leaflet'], factory) :
+	(global = typeof globalThis !== 'undefined' ? globalThis : global || self, (global.L = global.L || {}, global.L.Control = global.L.Control || {}, global.L.Control.FullScreen = factory(global.L)));
+})(this, (function (leaflet) { 'use strict';
 
 	if (typeof document === 'undefined') {
 		console.warn('"window.document" is undefined; leaflet.fullscreen requires this object to access the DOM');
@@ -278,6 +278,6 @@
 		}
 	});
 
-	exports.FullScreen = FullScreen;
+	return FullScreen;
 
 }));

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,42 +1,46 @@
 import { copyFileSync } from 'fs';
 
-export default {
-	input: 'src/Control.FullScreen.js',
-	external: ['leaflet'],
-	output: [
-		{
-			file: 'dist/Control.FullScreen.js',
-			format: 'es',
-			banner: `/*!
+const banner = `/*!
  * leaflet.fullscreen
  * (c) Bruno B.; MIT License
  * https://github.com/brunob/leaflet.fullscreen
  */
-/*! GENERATED FILE - DO NOT EDIT DIRECTLY. Edit files in src/ and run 'npm run build' */`,
+/*! GENERATED FILE - DO NOT EDIT DIRECTLY. Edit files in src/ and run 'npm run build' */`;
+
+export default [
+	// ESM build (supports named and default exports)
+	{
+		input: 'src/Control.FullScreen.js',
+		external: ['leaflet'],
+		output: {
+			file: 'dist/Control.FullScreen.js',
+			format: 'es',
+			banner,
 			sourcemap: false
 		},
-		{
+		plugins: [
+			{
+				name: 'copy-assets',
+				buildEnd() {
+					copyFileSync('src/Control.FullScreen.css', 'dist/Control.FullScreen.css');
+				}
+			}
+		]
+	},
+	// UMD build (uses separate entry for clean default export → L.Control.FullScreen)
+	{
+		input: 'src/umd-entry.js',
+		external: ['leaflet'],
+		output: {
 			file: 'dist/Control.FullScreen.umd.js',
 			format: 'umd',
 			name: 'L.Control.FullScreen',
+			exports: 'default',
 			globals: {
 				leaflet: 'L'
 			},
-			banner: `/*!
- * leaflet.fullscreen
- * (c) Bruno B.; MIT License
- * https://github.com/brunob/leaflet.fullscreen
- */
-/*! GENERATED FILE - DO NOT EDIT DIRECTLY. Edit files in src/ and run 'npm run build' */`,
+			banner,
 			sourcemap: false
 		}
-	],
-	plugins: [
-		{
-			name: 'copy-assets',
-			buildEnd() {
-				copyFileSync('src/Control.FullScreen.css', 'dist/Control.FullScreen.css');
-			}
-		}
-	]
-};
+	}
+];

--- a/src/Control.FullScreen.js
+++ b/src/Control.FullScreen.js
@@ -268,5 +268,5 @@ Map.include({
 	}
 });
 
-// Export for ES modules
 export { FullScreen };
+export default FullScreen;

--- a/src/umd-entry.js
+++ b/src/umd-entry.js
@@ -1,0 +1,2 @@
+// UMD entry point - exports only the default for cleaner global (L.Control.FullScreen)
+export { default } from './Control.FullScreen.js';


### PR DESCRIPTION
- Add default export alongside named export
- Add separate UMD entry point for clean default export
- Update README to remove non-functional fullscreenControl option
- Update demo to use old simplified syntax

Fixes the redundant L.Control.FullScreen.FullScreen introduced in v5 and mentioned in #238.