### PR TITLE
feat: add built-in TypeScript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "dist/Control.FullScreen.js",
   "module": "dist/Control.FullScreen.js",
   "browser": "dist/Control.FullScreen.umd.js",
+  "types": "types/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/Control.FullScreen.js",
@@ -15,6 +16,7 @@
   },
   "files": [
     "dist/",
+    "types/",
     "CHANGELOG.md"
   ],
   "scripts": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,119 @@
+declare module 'leaflet' {
+	interface FullScreenOptions extends ControlOptions {
+		/**
+		 * Position of the control.
+		 * @default 'topleft'
+		 */
+		position?: ControlPosition;
+
+		/**
+		 * Title of the button when not in fullscreen mode.
+		 * @default 'Full Screen'
+		 */
+		title?: string;
+
+		/**
+		 * Title of the button when in fullscreen mode.
+		 * @default 'Exit Full Screen'
+		 */
+		titleCancel?: string;
+
+		/**
+		 * Custom HTML content for the button.
+		 * If not provided, a default icon is used.
+		 */
+		content?: string;
+
+		/**
+		 * Force the control to be separate from the zoom control.
+		 * @default false
+		 */
+		forceSeparateButton?: boolean;
+
+		/**
+		 * Force pseudo-fullscreen mode (CSS-based) instead of native fullscreen API.
+		 * @default false
+		 */
+		forcePseudoFullscreen?: boolean;
+
+		/**
+		 * DOM element to make fullscreen instead of the map container.
+		 * Can be a CSS selector string or an HTMLElement.
+		 * @default false
+		 */
+		fullscreenElement?: HTMLElement | false;
+	}
+
+	interface MapOptions {
+		/**
+		 * Whether to add a fullscreen control to the map.
+		 * Can be `true` for default options or an options object.
+		 */
+		fullscreenControl?: boolean | FullScreenOptions;
+
+		/**
+		 * Options for the fullscreen control (if fullscreenControl is true).
+		 */
+		fullscreenControlOptions?: FullScreenOptions;
+	}
+
+	interface Map {
+		/**
+		 * Reference to the fullscreen control instance.
+		 */
+		fullscreenControl?: Control.FullScreen;
+
+		/**
+		 * Whether the map is currently in fullscreen mode.
+		 */
+		_isFullscreen?: boolean;
+
+		/**
+		 * Toggle fullscreen mode on the map.
+		 */
+		toggleFullscreen(): void;
+	}
+
+	/**
+	 * Events fired by the fullscreen control.
+	 */
+	interface LeafletEventHandlerFnMap {
+		/**
+		 * Fired when the map enters fullscreen mode.
+		 */
+		enterFullscreen?: LeafletEventHandlerFn;
+
+		/**
+		 * Fired when the map exits fullscreen mode.
+		 */
+		exitFullscreen?: LeafletEventHandlerFn;
+	}
+
+	namespace Control {
+		/**
+		 * A control that adds fullscreen functionality to the map.
+		 */
+		class FullScreen extends Control {
+			options: FullScreenOptions;
+
+			constructor(options?: FullScreenOptions);
+
+			/**
+			 * Toggle fullscreen mode.
+			 */
+			toggleFullScreen(): void;
+		}
+
+		/**
+		 * Creates a new fullscreen control.
+		 */
+		function fullscreen(options?: FullScreenOptions): FullScreen;
+	}
+
+	namespace control {
+		/**
+		 * Creates a new fullscreen control.
+		 */
+		function fullscreen(options?: FullScreenOptions): Control.FullScreen;
+	}
+}


### PR DESCRIPTION
This PR implements the suggestion from @mickaeltr in [issue #208](https://github.com/brunob/leaflet.fullscreen/issues/208#issuecomment-3618278119) to include TypeScript definitions directly in this package.

This does not mean converting the plugin into a TypeScript project. Nevertheless, adding a types file to the repo has several advantages.

## Changes
- Added `types/index.d.ts` with complete type definitions for all options, events, and map extensions.
- Updated `package.json` to export types (`"types": "types/index.d.ts"`).

## Benefits

### For users of this plugin
- **Out-of-the-box TypeScript support:** No need to install a separate `@types` package.
- **Better editor support:** Users in modern IDEs (VS Code, WebStorm, etc.) will get better autocompletion and documentation on hover for options like `forcePseudoFullscreen`, even when using plain JavaScript.

### For developers of this plugin
- **Better DX:** IDEs can now validate the internal code against these types, helping to catch bugs early.
- **Documentation:** The `.d.ts` file serves as a strict contract of the public API.

## Trade-offs
- **Maintenance:** The `types/index.d.ts` file needs to be updated manually when adding new features or changing the API.
  - However, since this happens in the same repo, it's much easier than updating DefinitelyTyped. I also consider the plugin to be feature complete, so there will be little need for changes in the future.
- **File size:** The package size increases slightly (by a few KB), which is negligible.