### PR TITLE
test: add regression test for fullscreenControl init hook

### DIFF
--- a/spec/Control.FullScreen.spec.js
+++ b/spec/Control.FullScreen.spec.js
@@ -8,6 +8,11 @@ const { FullScreen } = await import('../src/Control.FullScreen.js');
 
 describe('FullScreen Control', () => {
 	let map;
+	const mountControl = (options) => {
+		const control = new FullScreen(options);
+		map.addControl(control);
+		return control;
+	};
 
 	beforeEach(() => {
 		map = new Map(document.createElement('div'));
@@ -61,32 +66,28 @@ describe('FullScreen Control', () => {
 
 	describe('DOM Creation', () => {
 		it('should create DOM elements when added to map', () => {
-			const control = new FullScreen();
-			control._map = map;
-			const container = control.onAdd(map);
+			const control = mountControl();
+			const container = control._container;
 
 			assert.ok(container instanceof HTMLElement, 'Should return an HTML element');
 			assert.ok(container.querySelector('a'), 'Should contain a link element');
 		});
 
 		it('should support custom content in button', () => {
-			const control = new FullScreen({
+			const control = mountControl({
 				content: '<span>FS</span>'
 			});
-			control._map = map;
-			const container = control.onAdd(map);
-			const link = container.querySelector('a');
+			const link = control.link;
 
 			assert.ok(link, 'Link should exist');
 			assert.strictEqual(control.options.content, '<span>FS</span>');
 		});
 
 		it('should create separate button when forceSeparateButton is true', () => {
-			const control = new FullScreen({
+			const control = mountControl({
 				forceSeparateButton: true
 			});
-			control._map = map;
-			const container = control.onAdd(map);
+			const container = control._container;
 
 			assert.ok(container.classList.contains('leaflet-bar'));
 		});
@@ -94,19 +95,15 @@ describe('FullScreen Control', () => {
 
 	describe('Accessibility (ARIA)', () => {
 		it('should set aria attributes on button', () => {
-			const control = new FullScreen();
-			control._map = map;
-			const container = control.onAdd(map);
-			const link = container.querySelector('a');
+			const control = mountControl();
+			const link = control.link;
 
 			assert.strictEqual(link.getAttribute('role'), 'button');
 			assert.ok(link.hasAttribute('aria-label'));
 		});
 
 		it('should set aria-pressed when entering fullscreen', async() => {
-			const control = new FullScreen();
-			control._map = map;
-			control.onAdd(map);
+			const control = mountControl();
 			const link = control.link;
 
 			await control.toggleFullScreen();
@@ -114,9 +111,7 @@ describe('FullScreen Control', () => {
 		});
 
 		it('should update aria-pressed when exiting fullscreen', async() => {
-			const control = new FullScreen();
-			control._map = map;
-			control.onAdd(map);
+			const control = mountControl();
 			const link = control.link;
 
 			await control.toggleFullScreen();
@@ -134,18 +129,14 @@ describe('FullScreen Control', () => {
 		});
 
 		it('should set _isFullscreen flag on map', async() => {
-			const control = new FullScreen();
-			control._map = map;
-			control.onAdd(map);
+			const control = mountControl();
 
 			await control.toggleFullScreen();
 			assert.strictEqual(map._isFullscreen, true);
 		});
 
 		it('should toggle fullscreen state', async() => {
-			const control = new FullScreen();
-			control._map = map;
-			control.onAdd(map);
+			const control = mountControl();
 
 			await control.toggleFullScreen();
 			assert.strictEqual(map._isFullscreen, true);
@@ -155,9 +146,7 @@ describe('FullScreen Control', () => {
 		});
 
 		it('should toggle CSS class on state change', async() => {
-			const control = new FullScreen();
-			control._map = map;
-			control.onAdd(map);
+			const control = mountControl();
 			const link = control.link;
 
 			assert.ok(!link.classList.contains('leaflet-fullscreen-on'));
@@ -170,9 +159,7 @@ describe('FullScreen Control', () => {
 		});
 
 		it('should update title when toggling', async() => {
-			const control = new FullScreen();
-			control._map = map;
-			control.onAdd(map);
+			const control = mountControl();
 			const link = control.link;
 
 			assert.strictEqual(link.title, 'Full Screen');
@@ -185,9 +172,7 @@ describe('FullScreen Control', () => {
 		});
 
 		it('should invalidate map size on toggle', async() => {
-			const control = new FullScreen();
-			control._map = map;
-			control.onAdd(map);
+			const control = mountControl();
 
 			let invalidateCalled = 0;
 			const originalInvalidateSize = map.invalidateSize;
@@ -206,9 +191,7 @@ describe('FullScreen Control', () => {
 
 	describe('Events', () => {
 		it('should fire enterFullscreen event', async() => {
-			const control = new FullScreen();
-			control._map = map;
-			control.onAdd(map);
+			const control = mountControl();
 
 			let eventFired = false;
 			map.on('enterFullscreen', () => {
@@ -220,9 +203,7 @@ describe('FullScreen Control', () => {
 		});
 
 		it('should fire exitFullscreen event on toggle off', async() => {
-			const control = new FullScreen();
-			control._map = map;
-			control.onAdd(map);
+			const control = mountControl();
 
 			let exitEventFired = false;
 			map.on('exitFullscreen', () => {
@@ -236,9 +217,7 @@ describe('FullScreen Control', () => {
 		});
 
 		it('should handle external fullscreen exit', async() => {
-			const control = new FullScreen();
-			control._map = map;
-			control.onAdd(map);
+			const control = mountControl();
 
 			let exitEventFired = false;
 			map.on('exitFullscreen', () => {
@@ -260,11 +239,9 @@ describe('FullScreen Control', () => {
 
 	describe('Options & Features', () => {
 		it('should use pseudo-fullscreen when forcePseudoFullscreen is true', async() => {
-			const control = new FullScreen({
+			const control = mountControl({
 				forcePseudoFullscreen: true
 			});
-			control._map = map;
-			control.onAdd(map);
 
 			const container = map.getContainer();
 
@@ -279,12 +256,10 @@ describe('FullScreen Control', () => {
 
 		it('should support custom fullscreenElement', async() => {
 			const customElement = document.createElement('div');
-			const control = new FullScreen({
+			const control = mountControl({
 				fullscreenElement: customElement,
 				forcePseudoFullscreen: true
 			});
-			control._map = map;
-			control.onAdd(map);
 
 			await control.toggleFullScreen();
 			assert.ok(customElement.classList.contains('leaflet-pseudo-fullscreen'));
@@ -294,9 +269,7 @@ describe('FullScreen Control', () => {
 		});
 
 		it('should provide map.fullscreenControl reference', async() => {
-			const control = new FullScreen();
-			control._map = map;
-			control.onAdd(map);
+			const control = mountControl();
 
 			assert.ok(control.toggleFullScreen);
 			assert.ok(map.fullscreenControl);
@@ -306,13 +279,11 @@ describe('FullScreen Control', () => {
 
 	describe('Cleanup', () => {
 		it('should remove event listeners on onRemove', () => {
-			const control = new FullScreen();
-			control._map = map;
-			control.onAdd(map);
+			const control = mountControl();
 
 			assert.ok(control.link);
 
-			control.onRemove();
+			map.removeControl(control);
 
 			// If no errors thrown, cleanup was successful
 			assert.ok(true);

--- a/spec/Control.FullScreen.spec.js
+++ b/spec/Control.FullScreen.spec.js
@@ -37,6 +37,26 @@ describe('FullScreen Control', () => {
 			assert.strictEqual(control.options.forceSeparateButton, false);
 			assert.strictEqual(control.options.forcePseudoFullscreen, false);
 		});
+
+		it('should auto-create fullscreen control via map options init hook', () => {
+			const mapContainer = document.createElement('div');
+			document.body.appendChild(mapContainer);
+
+			const mapWithControlOption = new Map(mapContainer, {
+				fullscreenControl: true,
+				fullscreenControlOptions: {
+					position: 'topright',
+					title: 'Go Fullscreen'
+				}
+			});
+
+			assert.ok(mapWithControlOption.fullscreenControl, 'Control should be auto-added from map options');
+			assert.ok(mapWithControlOption.fullscreenControl instanceof FullScreen, 'Control should be a FullScreen instance');
+			assert.strictEqual(mapWithControlOption.fullscreenControl.options.position, 'topright');
+			assert.strictEqual(mapWithControlOption.fullscreenControl.options.title, 'Go Fullscreen');
+
+			mapWithControlOption.remove();
+		});
 	});
 
 	describe('DOM Creation', () => {


### PR DESCRIPTION
This is a follow-up to #292 and adds a regression test for the restored `fullscreenControl` InitHook behavior.

While touching the tests, I also did a small refactor to make them a bit closer to real usage by using the public control lifecycle (`addControl` / `removeControl`).